### PR TITLE
Add maven-war-plugin with version 2.2 (as by Maven 3.5.3)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,12 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>2.12.4</version>
         </plugin>
+        <plugin>
+          <!-- https://maven.apache.org/plugins/maven-war-plugin/ -->
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-war-plugin</artifactId>
+          <version>2.2</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
All remaining default-lifecycle-WAR-packaging plugins done: closes #5